### PR TITLE
Fixes #2 (depends on libstorj #382)

### DIFF
--- a/lib/ruby_libstorj/env.rb
+++ b/lib/ruby_libstorj/env.rb
@@ -14,9 +14,6 @@ module LibStorj
 
     def initialize(*options)
       @storj_env = ::LibStorj::Ext::Storj.method(:init_env).call(*options)
-      puts "@storj_env: #{@storj_env}"
-      puts "@storj_env.to_ptr: #{@storj_env.to_ptr}"
-      puts "@storj_env.to_ptr.address.to_s(16): #{@storj_env.to_ptr.address.to_s(16)}"
       @storj_env[:loop] = ::Libuv::Ext.default_loop
     end
 

--- a/lib/ruby_libstorj/env.rb
+++ b/lib/ruby_libstorj/env.rb
@@ -20,6 +20,10 @@ module LibStorj
       @storj_env[:loop] = ::Libuv::Ext.default_loop
     end
 
+    def destroy
+      ::LibStorj::Ext::Storj.destroy_env @storj_env
+    end
+
     def get_info(&block)
       handle_cast_proc = Proc.new do |handle|
         FFI::Function.new :void, %i[string string], handle

--- a/lib/ruby_libstorj/env.rb
+++ b/lib/ruby_libstorj/env.rb
@@ -1,7 +1,7 @@
 module LibStorj
   class Env
     require 'libuv'
-    attr_reader :pointer
+    attr_reader :storj_env
 
     C_ANALOGUE = ::LibStorj::Ext::Storj::Env
     JSON_C_CAST_METHOD = ::LibStorj::Ext::JsonC.method :parse_json
@@ -13,8 +13,8 @@ module LibStorj
     end
 
     def initialize(*options)
-      @pointer = ::LibStorj::Ext::Storj.method(:init_env).call(*options)
-      @pointer[:loop] = ::Libuv::Ext.default_loop
+      @storj_env = ::LibStorj::Ext::Storj.method(:init_env).call(*options)
+      @storj_env[:loop] = ::Libuv::Ext.default_loop
     end
 
     def get_info(&block)
@@ -38,7 +38,7 @@ module LibStorj
 
       reactor do |reactor|
         reactor.work do
-          ::LibStorj::Ext::Storj.get_info @pointer, handle, after_work_cb
+          ::LibStorj::Ext::Storj.get_info @storj_env, handle, after_work_cb
         end
       end
     end
@@ -65,7 +65,7 @@ module LibStorj
 
       reactor do |reactor|
         reactor.work do
-          ::LibStorj::Ext::Storj.get_buckets @pointer, work_cb, after_work_cb
+          ::LibStorj::Ext::Storj.get_buckets @storj_env, work_cb, after_work_cb
         end
       end
     end

--- a/lib/ruby_libstorj/env.rb
+++ b/lib/ruby_libstorj/env.rb
@@ -14,6 +14,9 @@ module LibStorj
 
     def initialize(*options)
       @storj_env = ::LibStorj::Ext::Storj.method(:init_env).call(*options)
+      puts "@storj_env: #{@storj_env}"
+      puts "@storj_env.to_ptr: #{@storj_env.to_ptr}"
+      puts "@storj_env.to_ptr.address.to_s(16): #{@storj_env.to_ptr.address.to_s(16)}"
       @storj_env[:loop] = ::Libuv::Ext.default_loop
     end
 

--- a/lib/ruby_libstorj/ext/ext.rb
+++ b/lib/ruby_libstorj/ext/ext.rb
@@ -32,6 +32,10 @@ module LibStorj
       # ::LibStorj::UV::
       ], :int)
 
+      attach_function('destroy_env', 'storj_destroy_env', [
+          Env.ptr
+      ], :int)
+
       attach_function('init_env', 'storj_init_env', [
           BridgeOptions.ptr,
           EncryptOptions.ptr,

--- a/spec/env_spec.rb
+++ b/spec/env_spec.rb
@@ -9,6 +9,12 @@ RSpec.shared_examples '@instance of described class' do
       fail(error)
     end
   end
+
+  after do
+    # (see https://github.com/Storj/ruby-libstorj/issues/2)
+    # Process.RLIMIT_MEMLOCKA #=> 8
+    @instance.destroy
+  end
 end
 
 RSpec.describe LibStorj::Env, extra_broken: true do

--- a/spec/env_spec.rb
+++ b/spec/env_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe LibStorj::Env, extra_broken: true do
   describe 'new' do
     include_examples '@instance of described class'
 
-    it 'doesn\'t segfault', working: true, broken: true do
+    it 'doesn\'t segfault' do
       # pass
     end
 
-    it 'returns an instance of the described class', working: true, broken: true do
+    it 'returns an instance of the described class' do
       expect(@instance).to be_an_instance_of(described_class)
     end
   end
@@ -33,11 +33,11 @@ RSpec.describe LibStorj::Env, extra_broken: true do
   describe '@pointer' do
     include_examples '@instance of described class'
 
-    it 'does not point to NULL', working: true, broken: true do
+    it 'does not point to NULL' do
       expect(@instance.storj_env.to_ptr).not_to equal(FFI::Pointer::NULL)
     end
 
-    it 'is an instance of the struct wrapper corresponding to its C analogue', working: true, broken: true do
+    it 'is an instance of the struct wrapper corresponding to its C analogue' do
       expect(@instance.storj_env).to be_an_instance_of(described_class::C_ANALOGUE)
     end
   end
@@ -46,7 +46,7 @@ RSpec.describe LibStorj::Env, extra_broken: true do
     context 'without error' do
       include_examples '@instance of described class'
 
-      it 'yields with an error value of `nil` and response matching regex: /^{\W+swagger/', working: true, broken: true do
+      it 'yields with an error value of `nil` and response matching regex: /^{\W+swagger/' do
         expect do |block|
           @instance.get_info(&block)
         end.to yield_with_args(NilClass, /^{\W+swagger/)
@@ -56,7 +56,7 @@ RSpec.describe LibStorj::Env, extra_broken: true do
     context 'with error' do
       include_examples '@instance of described class'
 
-      it 'yields with a non-nil error value and "null" response', working: true, broken: true do
+      it 'yields with a non-nil error value and "null" response' do
         @instance.storj_env[:bridge_options][:host].write_string 'a.nonexistant.example'
 
         expect do |block|
@@ -71,13 +71,13 @@ RSpec.describe LibStorj::Env, extra_broken: true do
     context 'without error' do
       include_examples '@instance of described class'
 
-      it 'yields a string response and a nil error', working: true, broken: true do
+      it 'yields a string response and a nil error' do
         expect do |block|
           @instance.get_buckets(&block)
         end.to yield_with_args(NilClass, String)
       end
 
-      it 'yields a response containing a JSON array of buckets with `name`s,', working: false, broken: true do
+      it 'yields a response containing a JSON array of buckets with `name`s' do
         require 'json'
 
         @instance.get_buckets do |error, response|
@@ -90,31 +90,15 @@ RSpec.describe LibStorj::Env, extra_broken: true do
     end
 
     context 'with error' do
-      # include_examples '@instance of described class'
+      include_examples '@instance of described class'
 
-      it 'yields with a non-nil error value and "null" response', working: true, broken: true do
-        ballz = LibStorj::Env.new(*default_options)
+      it 'yields with a non-nil error value and "null" response' do
         # (see https://tools.ietf.org/html/rfc2606)
-        ballz.storj_env[:bridge_options][:host].write_string 'a.nonexistant.example'
+        @instance.storj_env[:bridge_options][:host].write_string 'a.nonexistant.example'
 
         expect do |block|
-          ballz.get_buckets(&block)
+          @instance.get_buckets(&block)
         end.to yield_with_args(/couldn't resolve host name/i, 'null')
-      end
-    end
-
-    context 'after about 9 instances' do
-      # include_examples '@instance of described class'
-      it 'blows up' do
-        boom = LibStorj::Env.new(*default_options)
-      end
-    end
-
-    context '...' do
-      # include_examples '@instance of described class'
-
-      it 'blows up' do
-        boom = LibStorj::Env.new(*default_options)
       end
     end
 


### PR DESCRIPTION
#### Depends on [libstorj #382](https://github.com/Storj/libstorj/pull/382)

Adds `LibStorj::Ext::Storj::Env#destroy` which binds to the newly exposed `storj_destroy_env`.